### PR TITLE
Fix additional direct peers connection strategy

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "@0x/contract-addresses": "8.7.0",
     "@fingerprintjs/fingerprintjs": "^3.3.6",
-    "@multiformats/multiaddr": "12.1.3",
+    "@multiformats/multiaddr": "12.5.1",
     "@railgun-community/cookbook": "^2.12.2",
     "@railgun-community/shared-models": "^8.0.1",
     "@railgun-community/waku-broadcaster-client-web": "^9.0.6",

--- a/desktop/src/worker/waku-broadcaster-client.tsx
+++ b/desktop/src/worker/waku-broadcaster-client.tsx
@@ -29,6 +29,26 @@ import { BroadcasterFindRandomBroadcasterForTokenParams } from '../react-shared/
 import { sendWakuError, sendWakuMessage } from './loggers';
 import { bridgeRegisterCall, triggerBridgeEvent } from './worker-ipc-service';
 
+/**
+ * Dials additional direct peers.
+ */
+const dialDirectPeers = async (
+  peerMultiaddrs: string[],
+): Promise<void> => {
+  const waku = WakuBroadcasterClient.getWakuCore();
+  if (!waku || peerMultiaddrs.length === 0) {
+    return;
+  }
+  for (const ma of peerMultiaddrs) {
+    try {
+      await waku.dial(ma);
+      sendWakuMessage(`Connected to direct peer: ${ma}`);
+    } catch (err) {
+      sendWakuError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+};
+
 const onBroadcasterStatusCallback = (data: BroadcasterStatusCallbackData) => {
   triggerBridgeEvent(BridgeEvent.OnBroadcasterStatusCallback, data);
 };
@@ -62,7 +82,7 @@ bridgeRegisterCall<BroadcasterStartParams, BroadcasterActionData>(
     const broadcasterOptions: BroadcasterOptions = {
       trustedFeeSigner,
       pubSubTopic,
-      additionalDirectPeers,
+      additionalDirectPeers: [],
       peerDiscoveryTimeout,
       poiActiveListKeys,
     };
@@ -72,6 +92,10 @@ bridgeRegisterCall<BroadcasterStartParams, BroadcasterActionData>(
       statusCallback,
       broadcasterDebugger,
     );
+
+    // Dial the direct peers on top of the already-discovered fleet peers.
+    void dialDirectPeers(additionalDirectPeers ?? []);
+
     return {};
   },
 );

--- a/desktop/src/worker/waku-broadcaster-client.tsx
+++ b/desktop/src/worker/waku-broadcaster-client.tsx
@@ -30,15 +30,33 @@ import { sendWakuError, sendWakuMessage } from './loggers';
 import { bridgeRegisterCall, triggerBridgeEvent } from './worker-ipc-service';
 
 /**
- * Dials additional direct peers.
+ * Polls for the Waku core to become available, then dials additional direct
+ * peers. Designed to run concurrently with WakuBroadcasterClient.start() so
+ * that the dialed peers can satisfy waitForPeers if fleet bootstrap fails.
  */
-const dialDirectPeers = async (
+const waitForWakuAndDialPeers = async (
   peerMultiaddrs: string[],
 ): Promise<void> => {
-  const waku = WakuBroadcasterClient.getWakuCore();
-  if (!waku || peerMultiaddrs.length === 0) {
+  if (peerMultiaddrs.length === 0) {
     return;
   }
+
+  const POLL_INTERVAL_MS = 500;
+  const MAX_ATTEMPTS = 240; // 2 minutes max polling
+
+  let waku = WakuBroadcasterClient.getWakuCore();
+  let attempts = 0;
+  while (!waku && attempts < MAX_ATTEMPTS) {
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+    waku = WakuBroadcasterClient.getWakuCore();
+    attempts += 1;
+  }
+
+  if (!waku) {
+    sendWakuError(new Error('Timed out waiting for Waku core to dial direct peers'));
+    return;
+  }
+
   for (const ma of peerMultiaddrs) {
     try {
       await waku.dial(ma);
@@ -86,6 +104,11 @@ bridgeRegisterCall<BroadcasterStartParams, BroadcasterActionData>(
       peerDiscoveryTimeout,
       poiActiveListKeys,
     };
+    // Start dialing direct peers concurrently. The helper polls for the
+    // Waku core (set before waitForPeers blocks), so the dialed peers can
+    // satisfy peer requirements even if fleet bootstrap fails.
+    const dialPromise = waitForWakuAndDialPeers(additionalDirectPeers ?? []);
+
     await WakuBroadcasterClient.start(
       chain,
       broadcasterOptions,
@@ -93,8 +116,8 @@ bridgeRegisterCall<BroadcasterStartParams, BroadcasterActionData>(
       broadcasterDebugger,
     );
 
-    // Dial the direct peers on top of the already-discovered fleet peers.
-    void dialDirectPeers(additionalDirectPeers ?? []);
+    // Ensure any remaining dial attempts complete after start succeeds.
+    await dialPromise.catch(() => {});
 
     return {};
   },

--- a/desktop/src/worker/waku-broadcaster-client.tsx
+++ b/desktop/src/worker/waku-broadcaster-client.tsx
@@ -25,6 +25,7 @@ import {
   BroadcasterStatusCallbackData,
   BroadcasterSupportsERC20TokenParams,
 } from '@react-shared';
+import { multiaddr } from '@multiformats/multiaddr';
 import { BroadcasterFindRandomBroadcasterForTokenParams } from '../react-shared/src';
 import { sendWakuError, sendWakuMessage } from './loggers';
 import { bridgeRegisterCall, triggerBridgeEvent } from './worker-ipc-service';
@@ -65,6 +66,60 @@ const waitForWakuAndDialPeers = async (
       sendWakuError(err instanceof Error ? err : new Error(String(err)));
     }
   }
+};
+
+/**
+ * Periodically checks whether each additional direct peer is still connected.
+ * If a peer has dropped from the peer table, re-dials it. This handles:
+ * - Peers silently disappearing from the peer table
+ * - Waku restarts (reinitWaku) that create a new LightNode without re-dialing
+ * - Initial dial failures
+ */
+const startDirectPeerHealthCheck = (peerMultiaddrs: string[]): void => {
+  if (peerMultiaddrs.length === 0) {
+    return;
+  }
+
+  const HEALTH_CHECK_INTERVAL_MS = 60_000;
+
+  const peerEntries = peerMultiaddrs.map(ma => ({
+    multiaddr: ma,
+    peerId: multiaddr(ma).getComponents().find(c => c.name === 'p2p')?.value ?? null,
+  }));
+
+  setInterval(async () => {
+    const waku = WakuBroadcasterClient.getWakuCore();
+    if (!waku || !waku.isStarted()) {
+      return;
+    }
+
+    const connectedPeerIds = new Set(
+      waku.libp2p
+        .getPeers()
+        .map((p: { toString(): string }) => p.toString()),
+    );
+
+    for (const entry of peerEntries) {
+      if (entry.peerId == null) {
+        continue;
+      }
+      if (connectedPeerIds.has(entry.peerId)) {
+        continue;
+      }
+
+      sendWakuMessage(
+        `Direct peer disconnected, re-dialing: ${entry.multiaddr}`,
+      );
+      try {
+        await waku.dial(entry.multiaddr);
+        sendWakuMessage(`Reconnected to direct peer: ${entry.multiaddr}`);
+      } catch (err) {
+        sendWakuError(
+          err instanceof Error ? err : new Error(String(err)),
+        );
+      }
+    }
+  }, HEALTH_CHECK_INTERVAL_MS);
 };
 
 const onBroadcasterStatusCallback = (data: BroadcasterStatusCallbackData) => {
@@ -118,6 +173,10 @@ bridgeRegisterCall<BroadcasterStartParams, BroadcasterActionData>(
 
     // Ensure any remaining dial attempts complete after start succeeds.
     await dialPromise.catch(() => {});
+
+    // Start periodic health check for direct peers so they are re-dialed
+    // if they drop from the peer table or after a Waku restart.
+    startDirectPeerHealthCheck(additionalDirectPeers ?? []);
 
     return {};
   },

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -4617,22 +4617,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@multiformats/multiaddr@npm:12.1.3":
-  version: 12.1.3
-  resolution: "@multiformats/multiaddr@npm:12.1.3"
-  dependencies:
-    "@chainsafe/is-ip": "npm:^2.0.1"
-    "@chainsafe/netmask": "npm:^2.0.0"
-    "@libp2p/interfaces": "npm:^3.3.1"
-    dns-over-http-resolver: "npm:^2.1.0"
-    multiformats: "npm:^11.0.0"
-    uint8arrays: "npm:^4.0.2"
-    varint: "npm:^6.0.0"
-  checksum: 10/aaa6366da88e9169eed07f1957c85c91ecc18f8f04e3984fa49ad9cc10109a5d77ea6b93afcb3390d8c23ae8e9e4735b2a773467084966109b8c793892224074
-  languageName: node
-  linkType: hard
-
-"@multiformats/multiaddr@npm:^12.0.0, @multiformats/multiaddr@npm:^12.2.3, @multiformats/multiaddr@npm:^12.3.0, @multiformats/multiaddr@npm:^12.4.4":
+"@multiformats/multiaddr@npm:12.5.1, @multiformats/multiaddr@npm:^12.0.0, @multiformats/multiaddr@npm:^12.2.3, @multiformats/multiaddr@npm:^12.3.0, @multiformats/multiaddr@npm:^12.4.4":
   version: 12.5.1
   resolution: "@multiformats/multiaddr@npm:12.5.1"
   dependencies:
@@ -20176,7 +20161,7 @@ __metadata:
     "@craco/craco": "npm:^7.0.0"
     "@electron/notarize": "npm:^2.5.0"
     "@fingerprintjs/fingerprintjs": "npm:^3.3.6"
-    "@multiformats/multiaddr": "npm:12.1.3"
+    "@multiformats/multiaddr": "npm:12.5.1"
     "@railgun-community/cookbook": "npm:^2.12.2"
     "@railgun-community/shared-models": "npm:^8.0.1"
     "@railgun-community/waku-broadcaster-client-web": "npm:^9.0.6"


### PR DESCRIPTION
### Problem
The `additionalDirectPeers` option in `BroadcasterOptions` doesn't add peers alongside the discovered fleet — it uses them as the **exclusive** set of peers to connect to. This creates a single centralization point that becomes a bottleneck, causing message loss when that peer is overloaded or overused.
### Solution
Instead of passing `additionalDirectPeers` into `BroadcasterOptions` (which replaces fleet peer discovery entirely), this PR passes an empty array so fleet peers are discovered normally, then dials the additional direct peers **manually after** startup. This ensures:
- Fleet peers are discovered and connected as the primary mesh
- Direct peers are layered on top as supplementary connections, not replacements
- No single peer becomes a bottleneck for all message traffic