### PR TITLE
fix: merkletree scan progress bar stuck at 50% on desktop

### DIFF
--- a/desktop/src/services/engine/engine.tsx
+++ b/desktop/src/services/engine/engine.tsx
@@ -220,18 +220,19 @@ const handleMerkletreeScanUpdate = debounce(async (
 
   const progressRounded = progress.toFixed(2);
   const currentProgress = merkletreeStatus?.progress ?? 0;
-  const progressDiff = Math.abs(parseFloat(progressRounded) - currentProgress);
-
+  const incomingProgress = parseFloat(progressRounded);
+  const progressDiff = Math.abs(incomingProgress - currentProgress);
 
   logDev(
     `Scan status for ${merkletreeType} merkletree: ${scanStatus}, progress ${progressRounded}. Chain: ${chain.id}`,
   );
   if (
-    (progressDiff - currentProgress) < Constants.MIN_PROGRESS_UPDATE
+    incomingProgress <= currentProgress &&
+    progressDiff < Constants.MIN_PROGRESS_UPDATE
   ) {
     return;
   }
-  
+
 
   if (scanStatus === MerkletreeScanStatus.Updated) {
     dispatch(


### PR DESCRIPTION
## Problem

The \"RAILGUN balances updating\" progress bar on desktop gets stuck at ~50% and never advances further.

## Root Cause

In `desktop/src/services/engine/engine.tsx`, the throttle condition inside `handleMerkletreeScanUpdate` is incorrect:

```ts
// Before (buggy)
const progressDiff = Math.abs(parseFloat(progressRounded) - currentProgress);

if (
  (progressDiff - currentProgress) < Constants.MIN_PROGRESS_UPDATE
) {
  return;
}
```

Once `currentProgress` has any non-zero value, the expression `progressDiff - currentProgress` is almost always negative. A negative number is always less than `MIN_PROGRESS_UPDATE` (0.01), so **every subsequent progress event is silently dropped**. The UI freezes at whatever value was first dispatched (typically ~50%).

## Fix

Align the desktop logic with the correct mobile implementation (`mobile/src/services/engine/engine.tsx`): only skip the update when the incoming progress is not an increase **and** the difference is below the minimum threshold.

```ts
// After (fixed)
const incomingProgress = parseFloat(progressRounded);
const progressDiff = Math.abs(incomingProgress - currentProgress);

if (
  incomingProgress <= currentProgress &&
  progressDiff < Constants.MIN_PROGRESS_UPDATE
) {
  return;
}
```

This correctly throttles redundant/backward events while allowing all forward-progress updates to reach the Redux store and update the UI.

## Verification

The mobile version already uses equivalent logic and does not exhibit this bug. The desktop fix mirrors that pattern.