### PR TITLE
Fix unfair RelayAdapt broadcaster fees

### DIFF
--- a/desktop/src/react-shared/src/hooks/transaction/useGasFeeWatcher.tsx
+++ b/desktop/src/react-shared/src/hooks/transaction/useGasFeeWatcher.tsx
@@ -1,5 +1,5 @@
 import {
-  calculateMaximumGas,
+  calculateTotalGas,
   isDefined,
   TransactionGasDetails,
 } from '@railgun-community/shared-models';
@@ -15,9 +15,9 @@ export const useGasFeeWatcher = (
 
   useEffect(() => {
     if (selectedBroadcasterLocked && gasDetails) {
-      const maximumGas = calculateMaximumGas(gasDetails);
+      const totalGas = calculateTotalGas(gasDetails);
       const threshold =
-        maximumGas * 10000n + BigInt(changeThresholdBasisPoints) / 10000n;
+        totalGas * 10000n + BigInt(changeThresholdBasisPoints) / 10000n;
       setSavedMaximumGasThreshold(threshold);
       return;
     }
@@ -29,8 +29,8 @@ export const useGasFeeWatcher = (
     if (!isDefined(savedMaximumGasThreshold) || !gasDetails) {
       return false;
     }
-    const maximumGas = calculateMaximumGas(gasDetails);
-    if (maximumGas >= savedMaximumGasThreshold) {
+    const totalGas = calculateTotalGas(gasDetails);
+    if (totalGas >= savedMaximumGasThreshold) {
       return true;
     }
     return false;

--- a/desktop/src/react-shared/src/utils/transactions.tsx
+++ b/desktop/src/react-shared/src/utils/transactions.tsx
@@ -63,6 +63,17 @@ export const getProofTypeFromTransactionType = (
   }
 };
 
+export const gasDetailsWithMinimumEstimate = (
+  gasDetails: TransactionGasDetails,
+  minimumGasEstimate: bigint,
+): TransactionGasDetails => ({
+  ...gasDetails,
+  gasEstimate:
+    gasDetails.gasEstimate > minimumGasEstimate
+      ? gasDetails.gasEstimate
+      : minimumGasEstimate,
+});
+
 export const isShieldedFromToAddress = (
   transactionType: TransactionType,
   isPrivateTransaction: boolean,
@@ -460,8 +471,8 @@ export const broadcasterFeeInfoText = (
   const tokenFeePerUnitGas = BigInt(selectedBroadcaster.tokenFee.feePerUnitGas);
 
   const oneUnitGas = 10n ** 18n;
-  const maximumGas = calculateMaximumGas(gasDetails);
-  const tokenFee = (tokenFeePerUnitGas * maximumGas) / oneUnitGas;
+  const totalGas = calculateTotalGas(gasDetails);
+  const tokenFee = (tokenFeePerUnitGas * totalGas) / oneUnitGas;
   const tokenFeeString = formatUnits(tokenFee, selectedFeeToken.decimals);
   const priceText = formattedFeeTokenPrice(
     network,

--- a/desktop/src/views/screens/drawer/review-transaction/CrossContractReviewTransactionView.tsx
+++ b/desktop/src/views/screens/drawer/review-transaction/CrossContractReviewTransactionView.tsx
@@ -30,6 +30,7 @@ import {
   ERC20Amount,
   ERC20AmountRecipient,
   executeWithoutBroadcaster,
+  gasDetailsWithMinimumEstimate,
   getBroadcasterFilterPeerCount,
   getBroadcasterLightPushPeerCount,
   getBroadcasterMeshPeerCount,
@@ -94,6 +95,9 @@ type Props = {
   setSlippagePercent?: (slippage: number) => void;
   slippagePercent?: number;
 };
+
+// The wallet SDK subtracts 150k when encoding RelayAdapt's internal min gas.
+const RELAY_ADAPT_FEE_ESTIMATE_MIN_GAS_LIMIT = 150_000n;
 
 export const CrossContractReviewTransactionView: React.FC<Props> = ({
   authKey,
@@ -237,6 +241,10 @@ export const CrossContractReviewTransactionView: React.FC<Props> = ({
       isDefined(selectedBroadcaster),
       transactionGasDetails,
     );
+    const transactionGasDetailsForExecution = gasDetailsWithMinimumEstimate(
+      transactionGasDetails,
+      recipeOutput.minGasLimit,
+    );
 
     const broadcasterFeeERC20AmountRecipient =
       createBroadcasterFeeERC20AmountRecipient(
@@ -259,7 +267,7 @@ export const CrossContractReviewTransactionView: React.FC<Props> = ({
           broadcasterFeeERC20AmountRecipient,
           sendWithPublicWallet,
           overallBatchMinGasPrice,
-          transactionGasDetails,
+          transactionGasDetailsForExecution,
         ),
         delay(1000),
       ]);
@@ -381,7 +389,9 @@ export const CrossContractReviewTransactionView: React.FC<Props> = ({
       originalGasDetails,
       feeTokenDetails,
       sendWithPublicWallet,
-      recipeOutput.minGasLimit,
+      sendWithPublicWallet
+        ? recipeOutput.minGasLimit
+        : RELAY_ADAPT_FEE_ESTIMATE_MIN_GAS_LIMIT,
     );
   };
 

--- a/desktop/src/views/screens/drawer/unshield/UnshieldTokens/UnshieldConfirm/UnshieldConfirm.tsx
+++ b/desktop/src/views/screens/drawer/unshield/UnshieldTokens/UnshieldConfirm/UnshieldConfirm.tsx
@@ -20,6 +20,7 @@ import {
   ERC20Amount,
   ERC20AmountRecipient,
   executeWithoutBroadcaster,
+  gasDetailsWithMinimumEstimate,
   getBroadcasterFilterPeerCount,
   getBroadcasterLightPushPeerCount,
   getBroadcasterMeshPeerCount,
@@ -52,6 +53,8 @@ type Props = {
   balanceBucketFilter: RailgunWalletBalanceBucket[];
   unshieldToOriginShieldTxid?: string;
 };
+
+const BASE_TOKEN_UNSHIELD_EXECUTION_GAS_ESTIMATE = 5_000_000n;
 
 export const UnshieldConfirm = ({
   goBack,
@@ -231,6 +234,12 @@ export const UnshieldConfirm = ({
         const unshieldCall = isBaseTokenUnshield
           ? unauthenticatedWalletService.populateRailgunProvedUnshieldBaseToken
           : unauthenticatedWalletService.populateRailgunProvedUnshield;
+        const transactionGasDetailsForExecution = isBaseTokenUnshield
+          ? gasDetailsWithMinimumEstimate(
+              transactionGasDetails,
+              BASE_TOKEN_UNSHIELD_EXECUTION_GAS_ESTIMATE,
+            )
+          : transactionGasDetails;
         const [populateUnshieldResponse] = await Promise.all([
           unshieldCall(
             txidVersion.current,
@@ -242,7 +251,7 @@ export const UnshieldConfirm = ({
             broadcasterFeeERC20Amount,
             sendWithPublicWallet,
             overallBatchMinGasPrice,
-            transactionGasDetails,
+            transactionGasDetailsForExecution,
           ),
           delay(1000),
         ]);
@@ -380,7 +389,20 @@ export const UnshieldConfirm = ({
     sendWithPublicWallet: boolean,
   ) => {
     if (isBaseTokenUnshield) {
-      return Promise.resolve(5_000_000n);
+      if (sendWithPublicWallet) {
+        return Promise.resolve(BASE_TOKEN_UNSHIELD_EXECUTION_GAS_ESTIMATE);
+      }
+      return authenticatedWalletService.getGasEstimatesForUnprovenUnshieldBaseToken(
+        txidVersion,
+        networkName,
+        railWalletID,
+        memoText,
+        erc20AmountRecipients,
+        nftAmountRecipients,
+        originalGasDetails,
+        feeTokenDetails,
+        sendWithPublicWallet,
+      );
     }
     if (isDefined(unshieldToOriginShieldTxid)) {
       return authenticatedWalletService.getGasEstimatesForUnprovenUnshieldToOrigin(


### PR DESCRIPTION
## Why
Before this change, Railway used conservative execution gas limits to calculate broadcaster fees for RelayAdapt transactions.

This meant users were not only seeing inflated fee previews, but actually paying inflated fees to broadcasters.

This led to poor UX because broadcasters can publish token fee rates below a 1:1 gas-token rate, but users could still pay more than expected due to hidden gas-limit inflation and the execution buffer. The final fee was difficult to reason about because it did not map cleanly to estimated gas usage or the advertised broadcaster rate.

This change separates fee calculation from execution gas safety: execution gas limits remain conservative, while broadcaster fees are based on estimated gas usage, making final fees clearer and more predictable.

## Changes
- Use estimated gas for RelayAdapt broadcaster fee calculation instead of fixed execution gas minimums.
- Keep conservative RelayAdapt execution gas limits unchanged.
- Remove the 20% execution gas buffer from app-side broadcaster fee calculation.