### PR TITLE
fix: prevent tight pending transaction retry loop

### DIFF
--- a/desktop/src/react-shared/src/services/transactions/pending-transaction-watcher.test.tsx
+++ b/desktop/src/react-shared/src/services/transactions/pending-transaction-watcher.test.tsx
@@ -1,0 +1,130 @@
+import { Network } from '@railgun-community/shared-models';
+import {
+  SavedTransaction,
+  TransactionStatus,
+} from '../../models/transaction';
+import * as PromiseUtils from '../../utils/promises';
+import { PendingTransactionWatcher } from './pending-transaction-watcher';
+
+type WatcherInternals = {
+  isStarted: boolean;
+  watchingTransactionHashes: Record<string, Record<string, string>>;
+  ongoingPollIds: Record<string, Record<string, string>>;
+  pollForPendingTransaction: () => Promise<unknown>;
+};
+
+const watcher = PendingTransactionWatcher as unknown as WatcherInternals;
+
+jest.mock('../../bridge/bridge-poi', () => ({
+  getPOIRequiredForNetwork: jest.fn(),
+}));
+jest.mock('../../redux-store', () => ({
+  openShieldPOICountdownToast: jest.fn(),
+}));
+jest.mock('../../redux-store/reducers/saved-transactions-reducer', () => ({
+  setTransactions: jest.fn(),
+}));
+jest.mock('../../redux-store/reducers/toast-reducer', () => ({
+  enqueueAsyncToast: jest.fn(),
+}));
+jest.mock('../../redux-store/store', () => ({
+  store: { getState: jest.fn(() => ({ wallets: {} })) },
+}));
+jest.mock('../../utils/saved-transactions', () => ({
+  getSavedTransactionTXIDVersion: jest.fn(),
+  transactionShouldNavigateToPrivateBalance: jest.fn(),
+}));
+jest.mock('../../utils/tokens', () => ({
+  createNavigateToTokenInfoActionData: jest.fn(),
+}));
+jest.mock('../../utils/tx-receipt-parser', () => ({
+  findTokenTransferAmountFromReceipt: jest.fn(),
+}));
+jest.mock('../history/saved-transaction-store', () => ({
+  SavedTransactionStore: jest.fn(),
+}));
+jest.mock('../history/transaction-receipt-details-service', () => ({
+  TransactionReceiptDetailsService: jest.fn(),
+}));
+jest.mock('../providers/provider-service', () => ({
+  ProviderService: {},
+}));
+jest.mock('../wallet/wallet-balance-service', () => ({
+  getBaseTokenForNetwork: jest.fn(),
+  pullActiveWalletBalancesForNetwork: jest.fn(),
+  updateSingleERC20BalanceNetwork: jest.fn(),
+}));
+jest.mock('./poi-shield-countdown', () => ({
+  storeShieldCountdownTx: jest.fn(),
+}));
+
+describe('PendingTransactionWatcher', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    watcher.isStarted = false;
+    watcher.watchingTransactionHashes = {};
+    watcher.ongoingPollIds = {};
+  });
+
+  it('waits before retrying when the receipt provider rejects immediately', async () => {
+    let resolveDelay!: () => void;
+    const pendingDelay = new Promise<void>(resolve => {
+      resolveDelay = resolve;
+    });
+
+    let markDelayCalled!: () => void;
+    const delayCalled = new Promise<void>(resolve => {
+      markDelayCalled = resolve;
+    });
+    const delaySpy = jest
+      .spyOn(PromiseUtils, 'delay')
+      .mockImplementation(() => {
+        markDelayCalled();
+        return pendingDelay;
+      });
+
+    let markSecondPollStarted!: () => void;
+    const secondPollStarted = new Promise<void>(resolve => {
+      markSecondPollStarted = resolve;
+    });
+    const neverResolves = new Promise<never>(() => undefined);
+    const pollSpy = jest
+      .spyOn(watcher, 'pollForPendingTransaction')
+      .mockRejectedValueOnce(new Error('RPC rejected immediately'))
+      .mockImplementationOnce(() => {
+        markSecondPollStarted();
+        return neverResolves;
+      });
+
+    const startArgs = [
+      jest.fn(),
+      jest.fn(),
+      jest.fn(),
+    ] as unknown as Parameters<typeof PendingTransactionWatcher.start>;
+    PendingTransactionWatcher.start(...startArgs);
+
+    const network = { name: 'Ethereum' } as Network;
+    const transaction = {
+      id: '0xpending',
+      status: TransactionStatus.timedOut,
+    } as SavedTransaction;
+
+    void PendingTransactionWatcher.watchPendingTransaction(
+      network,
+      transaction,
+    );
+
+    const firstRetryStep = await Promise.race([
+      delayCalled.then(() => 'delay'),
+      secondPollStarted.then(() => 'poll'),
+    ]);
+    expect(firstRetryStep).toBe('delay');
+    expect(delaySpy).toHaveBeenCalledWith(15000);
+    expect(pollSpy).toHaveBeenCalledTimes(1);
+
+    resolveDelay();
+    await secondPollStarted;
+
+    expect(pollSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/desktop/src/react-shared/src/services/transactions/pending-transaction-watcher.tsx
+++ b/desktop/src/react-shared/src/services/transactions/pending-transaction-watcher.tsx
@@ -21,7 +21,7 @@ import { setTransactions } from '../../redux-store/reducers/saved-transactions-r
 import { enqueueAsyncToast } from '../../redux-store/reducers/toast-reducer';
 import { AppDispatch } from '../../redux-store/store';
 import { logDev, logDevError } from '../../utils/logging';
-import { poll } from '../../utils/promises';
+import { delay, poll } from '../../utils/promises';
 import {
   getSavedTransactionTXIDVersion,
   transactionShouldNavigateToPrivateBalance,
@@ -237,6 +237,7 @@ export class PendingTransactionWatcher {
       logDev(
         `[TransactionWatcher] Retrying transaction watcher. Tx hash: ${txHash}`,
       );
+      await delay(SharedConstants.RETRY_DELAY_SEC_GET_TX_FROM_HASH * 1000);
       return this.watchPendingTransaction(network, tx);
     }
 


### PR DESCRIPTION
## Summary

- Wait for the existing 15-second receipt polling interval before retrying a rejected pending transaction watcher.
- Prevent persistent RPC errors from creating an immediate renderer retry loop.
- Add focused regression coverage for retry ordering.

## Root cause

When getTransactionReceipt rejects, pollForPendingTransaction exits to the catch path. That path logs the error and recursively calls watchPendingTransaction immediately. A persistent provider error therefore repeatedly allocates Error stacks on the renderer thread and can make the desktop app unresponsive.

## Verification

- Regression test fails on main because the second poll starts before the delay.
- CI=true craco test --watchAll=false --runInBand pending-transaction-watcher.test.tsx passes with the patch.
- tsc --noEmit passes.
- Targeted ESLint for the new test passes.
- The optimized production build completes and its bundle contains the awaited retry interval.